### PR TITLE
Deny spawn-sync build script

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 allowBuilds:
   esbuild: true
-  spawn-sync: true
+  spawn-sync: false


### PR DESCRIPTION
## Summary
- pnpm-workspace.yaml の spawn-sync を `false` に変更しビルドスクリプトの実行を拒否
- spawn-sync は Node 0.12 未満向けの `child_process.spawnSync` ポリフィルで、fx-runner 経由で間接依存している。現代の Node には spawnSync が組み込まれているため、ネイティブヘルパーのコンパイルは不要。

## Test plan
- [x] `CI=true pnpm i` が成功する